### PR TITLE
Prevent send message icon from breaking on sending a message

### DIFF
--- a/src/sui/sui_window.c
+++ b/src/sui/sui_window.c
@@ -553,7 +553,7 @@ static void send_message_cancel(SuiWindow *self){
 
     gtk_image_set_from_icon_name(
             GTK_IMAGE(gtk_button_get_image(self->send_button)),
-            "dialog-ok", GTK_ICON_SIZE_BUTTON);
+            "document-send", GTK_ICON_SIZE_BUTTON);
 }
 
 static void on_destroy(SuiWindow *self){


### PR DESCRIPTION
After 4dda195 the icon would no longer match the one defined in the glade files.