### PR TITLE
Move buttons in headerbar to respect GNOME HIG

### DIFF
--- a/data/ui/window.glade
+++ b/data/ui/window.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkImage" id="connect_image">
@@ -52,7 +52,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="relief">none</property>
                     <child>
                       <object class="GtkImage" id="start_image">
                         <property name="visible">True</property>
@@ -83,7 +82,6 @@
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Connect</property>
                     <property name="image">connect_image</property>
-                    <property name="relief">none</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -99,7 +97,6 @@
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Join</property>
                     <property name="image">join_image</property>
-                    <property name="relief">none</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -167,7 +164,6 @@
                 <property name="can_focus">False</property>
                 <property name="focus_on_click">False</property>
                 <property name="receives_default">True</property>
-                <property name="relief">none</property>
                 <child>
                   <object class="GtkImage" id="menu_image">
                     <property name="visible">True</property>

--- a/data/ui/window.glade
+++ b/data/ui/window.glade
@@ -164,13 +164,9 @@
                 <property name="can_focus">False</property>
                 <property name="focus_on_click">False</property>
                 <property name="receives_default">True</property>
+                <property name="direction">none</property>
                 <child>
-                  <object class="GtkImage" id="menu_image">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">preferences-other</property>
-                    <property name="use_fallback">True</property>
-                  </object>
+                  <placeholder/>
                 </child>
               </object>
               <packing>

--- a/data/ui/window.glade
+++ b/data/ui/window.glade
@@ -5,25 +5,25 @@
   <object class="GtkImage" id="connect_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">network-server</property>
+    <property name="icon_name">network-server-symbolic</property>
     <property name="use_fallback">True</property>
   </object>
   <object class="GtkImage" id="join_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">contact-new</property>
+    <property name="icon_name">contact-new-symbolic</property>
     <property name="use_fallback">True</property>
   </object>
   <object class="GtkImage" id="plugin_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">application-x-addon</property>
+    <property name="icon_name">application-x-addon-symbolic</property>
     <property name="use_fallback">True</property>
   </object>
   <object class="GtkImage" id="send_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">document-send</property>
+    <property name="icon_name">document-send-symbolic</property>
     <property name="use_fallback">True</property>
   </object>
   <template class="SuiWindow" parent="GtkApplicationWindow">
@@ -56,7 +56,7 @@
                       <object class="GtkImage" id="start_image">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="icon_name">go-home</property>
+                        <property name="icon_name">go-home-symbolic</property>
                         <property name="use_fallback">True</property>
                       </object>
                     </child>

--- a/data/ui/window.glade
+++ b/data/ui/window.glade
@@ -48,6 +48,46 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
+                  <object class="GtkButton" id="connect_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Connect</property>
+                    <property name="image">connect_image</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="join_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="focus_on_click">False</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Join</property>
+                    <property name="image">join_image</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="linked"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="side_right_header_box">
+                <property name="name">f</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
                   <object class="GtkMenuButton" id="start_menu_button">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -56,7 +96,7 @@
                       <object class="GtkImage" id="start_image">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="icon_name">go-home-symbolic</property>
+                        <property name="icon_name">open-menu-symbolic</property>
                         <property name="use_fallback">True</property>
                       </object>
                     </child>
@@ -67,43 +107,12 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="side_right_header_box">
-                <property name="name">f</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkButton" id="connect_button">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Connect</property>
-                    <property name="image">connect_image</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
+                  <placeholder/>
                 </child>
-                <child>
-                  <object class="GtkButton" id="join_button">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="focus_on_click">False</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Join</property>
-                    <property name="image">join_image</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
+                <style>
+                  <class name="linked"/>
+                </style>
               </object>
               <packing>
                 <property name="pack_type">end</property>
@@ -166,7 +175,11 @@
                 <property name="receives_default">True</property>
                 <property name="direction">none</property>
                 <child>
-                  <placeholder/>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">view-more-symbolic</property>
+                  </object>
                 </child>
               </object>
               <packing>

--- a/src/sui/sui_side_bar.c
+++ b/src/sui/sui_side_bar.c
@@ -159,13 +159,13 @@ add_child(GtkWidget *child, SuiSideBar *sidebar){
 
     switch (chat->type) {
         case SRN_CHAT_TYPE_SERVER:
-            icon = "network-server";
+            icon = "network-server-symbolic";
             break;
         case SRN_CHAT_TYPE_CHANNEL:
-            icon = "system-users";
+            icon = "system-users-symbolic";
             break;
         case SRN_CHAT_TYPE_DIALOG:
-            icon = "user-available";
+            icon = "user-available-symbolic";
             break;
         default:
             icon = "";

--- a/src/sui/sui_window.c
+++ b/src/sui/sui_window.c
@@ -551,7 +551,7 @@ static void send_message(SuiWindow *self){
 
     gtk_image_set_from_icon_name(
             GTK_IMAGE(gtk_button_get_image(self->send_button)),
-            "document-revert", GTK_ICON_SIZE_BUTTON);
+            "document-revert-symbolic", GTK_ICON_SIZE_BUTTON);
 }
 
 static void send_message_cancel(SuiWindow *self){
@@ -563,7 +563,7 @@ static void send_message_cancel(SuiWindow *self){
 
     gtk_image_set_from_icon_name(
             GTK_IMAGE(gtk_button_get_image(self->send_button)),
-            "document-send", GTK_ICON_SIZE_BUTTON);
+            "document-send-symbolic", GTK_ICON_SIZE_BUTTON);
 }
 
 static void on_destroy(SuiWindow *self){

--- a/src/sui/sui_window.c
+++ b/src/sui/sui_window.c
@@ -66,7 +66,6 @@ struct _SuiWindow {
     GtkBox *side_header_box;
     GtkBox *side_left_header_box;
     GtkBox *side_right_header_box;
-    GtkImage *start_image;
     GtkMenuButton *start_menu_button;
     GtkButton *connect_button;
     GtkButton *join_button;
@@ -293,10 +292,6 @@ static void sui_window_constructed(GObject *object){
         gtk_window_set_titlebar(GTK_WINDOW(self), NULL);
         // Show the seperator
         gtk_widget_show(GTK_WIDGET(self->header_separator));
-    } else {
-        // Use appliaction icon instead of standard icon when CSD enabled
-        gtk_image_set_from_icon_name(self->start_image, PACKAGE,
-                GTK_ICON_SIZE_BUTTON);
     }
     update_header(self);
     update_title(self);
@@ -344,7 +339,6 @@ static void sui_window_class_init(SuiWindowClass *class){
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, side_header_box);
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, side_left_header_box);
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, side_right_header_box);
-    gtk_widget_class_bind_template_child(widget_class, SuiWindow, start_image);
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, start_menu_button);
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, connect_button);
     gtk_widget_class_bind_template_child(widget_class, SuiWindow, join_button);


### PR DESCRIPTION
More work on previous pull request. The right menu needs to be ported to a gmenumodel/popover.

![srain](https://user-images.githubusercontent.com/57196916/75781821-32465300-5d5e-11ea-8c15-b29d87a8bdae.png)

regards,