### PR TITLE
Script(update): allow setting CC variable via environment

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,9 @@
 # Complie C source codes and output object files to $(BUILD_DIR), then links
 # them together to get a executable $(TARGET).
 
-CC = gcc
+ifeq "$(origin CC)" "default"
+	CC = gcc
+endif
 DEFS = -D PACKAGE='"$(PACKAGE)"' \
 	   -D PACKAGE_NAME='"$(PACKAGE_NAME)"' \
 	   -D PACKAGE_VERSION='"$(PACKAGE_VERSION)"' \


### PR DESCRIPTION
Sets CC to gcc, if not otherwise specified.
https://www.gnu.org/software/make/manual/html_node/Origin-Function.html

This makes cross-compiling possible, as is seen working here: https://github.com/void-linux/void-packages/pull/19928