### PR TITLE
Truncate long message and Improve message transcoding

### DIFF
--- a/src/inc/srain.h
+++ b/src/inc/srain.h
@@ -33,8 +33,6 @@ typedef gboolean bool;
 #define SRN_TRUE    TRUE
 #define SRN_FALSE   FALSE
 
-/* All strings in Srain should be utf-8 sequence */
-#define SRN_ENCODING        "utf-8"
-#define SRN_FALLBACK_CHAR   "�"
+#define SRN_CODESET "UTF-8"
 
 #endif /* __SRAIN_H */

--- a/src/inc/utils.h
+++ b/src/inc/utils.h
@@ -27,6 +27,6 @@ time_t get_current_time_s(void);
 void time_to_str(time_t time, char *timestr, size_t size, const char *fmt);
 void str_assign(char **left, const char *right);
 bool str_is_empty(const char *str);
-void str_transcoding(char **str, const char *to, const char *from, const char *fallback);
+void str_transcoding(char **str, const char *from_codeset);
 
 #endif /* __UTILS_H */

--- a/src/lib/i18n.c
+++ b/src/lib/i18n.c
@@ -28,7 +28,7 @@ void i18n_init(){
      * the system locale data base
      */
     bindtextdomain (GETTEXT_PACKAGE,  PACKAGE_DATA_DIR "/locale");
-    bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+    bind_textdomain_codeset (GETTEXT_PACKAGE, SRN_CODESET);
 
     // Set the current default message catalog to DOMAINNAME.
     textdomain (GETTEXT_PACKAGE);

--- a/src/sirc/sirc.c
+++ b/src/sirc/sirc.c
@@ -227,8 +227,7 @@ static void on_recv_ready(GObject *obj, GAsyncResult *res, gpointer user_data){
     }
 
     /* Transcoding */
-    sirc_message_transcoding(imsg,
-            SRN_ENCODING, sirc->cfg->encoding, SRN_FALLBACK_CHAR);
+    sirc_message_transcoding(imsg, sirc->cfg->encoding);
     /* Handle event */
     sirc_event_hdr(sirc, imsg);
 

--- a/src/sirc/sirc_cmd.c
+++ b/src/sirc/sirc_cmd.c
@@ -126,6 +126,7 @@ int sirc_cmd_msg(SircSession *sirc, const char *chan, const char *msg){
     g_return_val_if_fail(!str_is_empty(chan), SRN_ERR);
     g_return_val_if_fail(!str_is_empty(msg), SRN_ERR);
 
+    const char *origin_msg = msg;
     while (msg) {
         SircCommandBuilder *builder = sirc_command_builder_new("PRIVMSG");
         if (!sirc_command_builder_add_middle(builder, chan)) {
@@ -134,7 +135,8 @@ int sirc_cmd_msg(SircSession *sirc, const char *chan, const char *msg){
             return SRN_ERR;
         }
         msg = sirc_command_builder_set_trailing(builder, msg);
-        if (msg == msg) {
+        // Prevent endless loop
+        if (msg == origin_msg) {
             sirc_command_builder_free(builder);
             g_warn_if_reached();
             return SRN_ERR;

--- a/src/sirc/sirc_cmd_builder.c
+++ b/src/sirc/sirc_cmd_builder.c
@@ -1,0 +1,174 @@
+/* Copyright (C) 2016-2020 Shengyu Zhang <i@silverrainz.me>
+ *
+ * This file is part of Srain.
+ *
+ * Srain is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+
+#include "sirc_cmd_builder.h"
+
+#define SIRC_RFC_CRLF "\r\n"
+#define SIRC_RFC_PARAM_DELIM " "
+#define SIRC_RFC_TRAILING_PREFIX ":"
+#define SIRC_RFC_MESSAGE_SZIE 512
+
+// The "prefix" means a servername or a nick!user@host in IRC message
+//
+// NOTE: We knowns that IRC message has a 512 bytes limit, even we sent a
+// 512-bytes IRC command to server, it still may be truncated by server when
+// server forward your command to your message destination.
+//
+// For example: You send command "PRIVMSG #archlinux-cn :BlahBlah..." whose
+// length is EXACTLY 512 bytes. When server forwards this command to everyone
+// in channel, it should add your user info as prefix of message, so it sent send:
+// ":nick!~user@hostname PRIVMSG #archlinux-cn :BlahBlah..." whose length MUST
+// exceeds 512bytes.
+//
+// It is hard to known length of user's prefix(a.k.a "nick!~user@hostname"),
+// so we have to use such an magic number:
+#define MAGIC_PREFIX_LEN 50
+
+struct _SircCommandBuilder {
+    char *cmd;
+    GList *middles; // List of middle param
+    char *trailing; // Trailing param
+    int expected_len; // Expected command length
+};
+
+/**
+ * @brief Create a SircCommandBuilder instance.
+ *
+ * @param cmd
+ *
+ * @return
+ */
+SircCommandBuilder* sirc_command_builder_new(const char *cmd) {
+    SircCommandBuilder *self;
+
+    self = g_malloc0(sizeof(SircCommandBuilder));
+    self->cmd = g_strdup(cmd);
+    self->expected_len = strlen(cmd) + strlen(SIRC_RFC_CRLF) + MAGIC_PREFIX_LEN;
+
+    return self;
+}
+
+/**
+ * @brief Free a SircCommandBuilder instance.
+ *
+ * @param self
+ */
+void sirc_command_builder_free(SircCommandBuilder *self) {
+    g_free(self->cmd);
+    g_list_free_full(self->middles, g_free);
+    g_free(self->trailing);
+    g_free(self);
+}
+
+/**
+ * @brief Add a middle param to builder.
+ *
+ * @param self
+ * @param param
+ *
+ * @return TRUE if the param is successfully added;
+ * FALSE if length of command exceeds SIRC_RFC_MESSAGE_SZIE after param added,
+ * nothing added.
+ */
+bool sirc_command_builder_add_middle(SircCommandBuilder *self, const char *param) {
+    int added_len;
+
+    added_len = strlen(SIRC_RFC_PARAM_DELIM) + strlen(param);
+    if (self->expected_len + added_len > SIRC_RFC_MESSAGE_SZIE) {
+        // Message length exceeds max message size, don't accpet param
+        return FALSE;
+    }
+
+    self->middles = g_list_append(self->middles, g_strdup(param));
+    self->expected_len += added_len;
+    return TRUE;
+}
+
+/**
+ * @brief Add a trailing param to builder.
+ *
+ * @param self
+ * @param param
+ *
+ * @return remaining param that failed to add to builder due to length
+ * limitation(SIRC_RFC_MESSAGE_SZIE). If whole param added, NULL is returned.
+ *
+ * UTF-8 param can be handled correctly.
+ */
+const char* sirc_command_builder_set_trailing(SircCommandBuilder *self, const char *param) {
+    // Repeat set is not allwoed
+    g_warn_if_fail(!self->trailing);
+
+    int added_len = strlen(SIRC_RFC_PARAM_DELIM) + strlen(SIRC_RFC_TRAILING_PREFIX) + strlen(param);
+    if (self->expected_len + added_len > SIRC_RFC_MESSAGE_SZIE) {
+        // Message length exceeds max message size, try truncate param
+        // NOTE: Please correctly handle UTF-8 chars
+        int exceeded_len = self->expected_len + added_len - SIRC_RFC_MESSAGE_SZIE;
+        const char *end = param + strlen(param);
+        const char *prev = param+ strlen(param);
+        for (;;) {
+            prev = g_utf8_find_prev_char(param, prev);
+            if (!prev) {
+                // Can not truncate
+                return param;
+            }
+            if (end - prev > exceeded_len) {
+                // Found that [param, prev) can just add to the command without
+                // exceeding the limit
+                break;
+            }
+        }
+        self->trailing = g_strndup(param, prev - param);
+        self->expected_len += strlen(SIRC_RFC_PARAM_DELIM) + strlen(SIRC_RFC_TRAILING_PREFIX) + (prev - param);
+        return prev;
+    }
+
+    self->trailing = g_strdup(param);
+    self->expected_len += added_len;
+    return NULL;
+}
+
+
+/**
+ * @brief Build a legal length IRC message from builder.
+ *
+ * @param self
+ *
+ * @return a newly-allocated string, must be freed by g_free().
+ */
+char* sirc_command_builder_build(SircCommandBuilder *self) {
+    GString *buf = g_string_new(self->cmd);
+    for (GList *elem = self->middles; elem != NULL; elem = g_list_next(elem)) {
+        const char *middle = elem->data;
+        g_string_append(buf, SIRC_RFC_PARAM_DELIM);
+        g_string_append(buf, middle);
+    }
+    if (self->trailing) {
+        g_string_append(buf, SIRC_RFC_PARAM_DELIM);
+        g_string_append(buf, SIRC_RFC_TRAILING_PREFIX);
+        g_string_append(buf, self->trailing);
+    }
+    g_string_append(buf, SIRC_RFC_CRLF);
+
+    g_warn_if_fail(buf->len == self->expected_len);
+    char *cmd = buf->str;
+    g_string_free(buf, FALSE);
+    return cmd;
+}

--- a/src/sirc/sirc_cmd_builder.c
+++ b/src/sirc/sirc_cmd_builder.c
@@ -23,7 +23,6 @@
 #define SIRC_RFC_CRLF "\r\n"
 #define SIRC_RFC_PARAM_DELIM " "
 #define SIRC_RFC_TRAILING_PREFIX ":"
-#define SIRC_RFC_MESSAGE_SZIE 512
 
 // The "prefix" means a servername or a nick!user@host in IRC message
 //
@@ -35,11 +34,12 @@
 // length is EXACTLY 512 bytes. When server forwards this command to everyone
 // in channel, it should add your user info as prefix of message, so it sent send:
 // ":nick!~user@hostname PRIVMSG #archlinux-cn :BlahBlah..." whose length MUST
-// exceeds 512bytes.
+// exceeds 512 bytes.
 //
 // It is hard to known length of user's prefix(a.k.a "nick!~user@hostname"),
 // so we have to use such an magic number:
 #define MAGIC_PREFIX_LEN 50
+#define SIRC_RFC_MESSAGE_SZIE (512 - MAGIC_PREFIX_LEN)
 
 struct _SircCommandBuilder {
     char *cmd;
@@ -60,7 +60,7 @@ SircCommandBuilder* sirc_command_builder_new(const char *cmd) {
 
     self = g_malloc0(sizeof(SircCommandBuilder));
     self->cmd = g_strdup(cmd);
-    self->expected_len = strlen(cmd) + strlen(SIRC_RFC_CRLF) + MAGIC_PREFIX_LEN;
+    self->expected_len = strlen(cmd) + strlen(SIRC_RFC_CRLF);
 
     return self;
 }

--- a/src/sirc/sirc_cmd_builder.h
+++ b/src/sirc/sirc_cmd_builder.h
@@ -1,0 +1,35 @@
+/* Copyright (C) 2016-2020 Shengyu Zhang <i@silverrainz.me>
+ *
+ * This file is part of Srain.
+ *
+ * Srain is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SIRC_COMMAND_BUILDER_H
+#define __SIRC_COMMAND_BUILDER_H
+
+#include "srain.h"
+
+/**
+ * @brief A helper for building legal length IRC command.
+ */
+typedef struct _SircCommandBuilder SircCommandBuilder;
+
+SircCommandBuilder* sirc_command_builder_new(const char *cmd);
+void sirc_command_builder_free(SircCommandBuilder *self);
+bool sirc_command_builder_add_middle(SircCommandBuilder *self, const char *param);
+const char* sirc_command_builder_set_trailing(SircCommandBuilder *self, const char *param);
+char* sirc_command_builder_build(SircCommandBuilder *self);
+
+#endif /* __SIRC_COMMAND_BUILDER_H */

--- a/src/sirc/sirc_config.c
+++ b/src/sirc/sirc_config.c
@@ -38,7 +38,7 @@ SrnRet sirc_config_check(SircConfig *cfg){
     }
 
     if (str_is_empty(cfg->encoding)) {
-        str_assign(&cfg->encoding, "UTF-8");
+        str_assign(&cfg->encoding, SRN_CODESET);
     }
 
     /* Check encoding */
@@ -46,15 +46,13 @@ SrnRet sirc_config_check(SircConfig *cfg){
         char *test;
         GError *err = NULL;
 
-        test = g_convert("", -1,
-                SRN_ENCODING, cfg->encoding,
-                NULL, NULL, &err);
+        // Just to test whether the codeset valid
+        test = g_convert("", -1, SRN_CODESET, cfg->encoding, NULL, NULL, &err);
         if (err){
             return RET_ERR(_("Invalid encoding in IRC config: %1$s"),
                     err->message);
-        } else {
-            g_free(test);
         }
+        g_free(test);
     }
 
     return SRN_OK;

--- a/src/sirc/sirc_parse.c
+++ b/src/sirc/sirc_parse.c
@@ -53,17 +53,15 @@ void sirc_message_free(SircMessage *imsg){
     g_free(imsg);
 }
 
-// FIXME: how to use fallback?
-void sirc_message_transcoding(SircMessage *imsg,
-        const char *to, const char *from, const char *fallback){
-    str_transcoding(&imsg->prefix, to, from, fallback);
-    str_transcoding(&imsg->nick, to, from, fallback);
-    str_transcoding(&imsg->user, to, from, fallback);
-    str_transcoding(&imsg->host, to, from, fallback);
-    str_transcoding(&imsg->cmd, to, from, fallback);
+void sirc_message_transcoding(SircMessage *imsg, const char *from_codeset) {
+    str_transcoding(&imsg->prefix, from_codeset);
+    str_transcoding(&imsg->nick, from_codeset);
+    str_transcoding(&imsg->user, from_codeset);
+    str_transcoding(&imsg->host, from_codeset);
+    str_transcoding(&imsg->cmd, from_codeset);
 
     for (int i = 0; i < imsg->nparam; i++){
-        str_transcoding(&imsg->params[i], to, from, fallback);
+        str_transcoding(&imsg->params[i], from_codeset);
     }
 }
 

--- a/src/sirc/sirc_parse.h
+++ b/src/sirc/sirc_parse.h
@@ -32,7 +32,7 @@ typedef struct {
 
 SircMessage *sirc_message_new();
 void sirc_message_free(SircMessage *imsg);
-void sirc_message_transcoding(SircMessage *imsg, const char *to, const char *from, const char *fallback);
+void sirc_message_transcoding(SircMessage *imsg, const char *from_codeset);
 SircMessage *sirc_parse(char *line);
 
 #endif /* __SIRC_PARSE_H */


### PR DESCRIPTION
- Introduce SircCommandBuilder to build IRC message with legal length
- Deal with invalid UTF-8 sequence
- Prevent uncessary transcoding