### PR TITLE
Add includes to avoid implicit declarations errors

### DIFF
--- a/src/lib/libecdsaauth/base64.c
+++ b/src/lib/libecdsaauth/base64.c
@@ -45,6 +45,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <assert.h>
+#include <ctype.h>
 
 static const char Base64[] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/src/sirc/sirc_cmd_builder.c
+++ b/src/sirc/sirc_cmd_builder.c
@@ -17,6 +17,7 @@
  */
 
 #include <glib.h>
+#include <string.h>
 
 #include "sirc_cmd_builder.h"
 

--- a/src/sui/sui_chat_buffer.c
+++ b/src/sui/sui_chat_buffer.c
@@ -25,6 +25,7 @@
  */
 
 #include <gtk/gtk.h>
+#include <string.h>
 
 #include "sui_buffer.h"
 #include "sui_chat_buffer.h"


### PR DESCRIPTION
To fix build errors on some systems.