### PR TITLE
fix typo in DBG code

### DIFF
--- a/src/render/mirc_colorize_renderer.c
+++ b/src/render/mirc_colorize_renderer.c
@@ -268,7 +268,7 @@ static void do_colorize(ColorlizeContext *ctx, char ch){
                 break;
         }
     } else {
-        DBG_FR("Closeing tag: 0x%x", ch);
+        DBG_FR("Closing tag: 0x%x", ch);
 
         // Closes all unclosed tags before the start tag corresponding to current tag
         for (int i = ctx->ptr - 1; i >= ptr; i--){


### PR DESCRIPTION
debian annoy me with warning, so here is my "big fix" :)
```
I: srain: spelling-error-in-binary usr/bin/srain Closeing Closing
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext or a similar tool, please fix the error in the translations
N:    as well as the English text to avoid making the translations fuzzy. With
N:    gettext, for example, this means you should also fix the spelling
N:    mistake in the corresponding msgids in the *.po files.
N:    
N:    You can often find the word in the source code by running:
N:    
N:     grep -rw <word> <source-tree>
N:    
N:    This tag may produce false positives for words that contain non-ASCII
N:    characters due to limitations in strings.
N:    
N:    Severity: info
N:    
N:    Check: binaries
N:
```