### PR TITLE
Sui(change): Use libappindicator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         sudo apt-get update;
         sudo apt-get install pkg-config gettext libgtk-3-dev libsoup2.4-dev libconfig-dev libssl-dev libsecret-1-dev \
-        glib-networking libgtk3.0 libsoup2.4 libconfig9 libsecret-1-0;
+        glib-networking libgtk3.0 libsoup2.4 libconfig9 libsecret-1-0 libappindicator3-dev;
     - name: Build
       run: |
         ./configure \

--- a/data/Makefile
+++ b/data/Makefile
@@ -24,8 +24,9 @@ config: builtin.cfg
 	$(INSTALL) -Dm644 "$<" "$(DESTDIR)$(PACKAGE_CONFIG_DIR)/$(PACKAGE)/$<"
 
 .PHONY: icons
-icons: icons/128x128/srain.png
-	$(INSTALL) -Dm644 "$<" "$(DESTDIR)$(PACKAGE_DATA_DIR)/icons/hicolor/128x128/apps/$(PACKAGE_APPID).png"
+icons: icons/128x128/srain.png icons/128x128/srain-red.png
+	$(INSTALL) -Dm644 "icons/128x128/srain.png" "$(DESTDIR)$(PACKAGE_DATA_DIR)/icons/hicolor/128x128/apps/$(PACKAGE_APPID).png"
+	$(INSTALL) -Dm644 "icons/128x128/srain-red.png" "$(DESTDIR)$(PACKAGE_DATA_DIR)/icons/hicolor/128x128/apps/$(PACKAGE_APPID)-red.png"
 
 .PHONY: themes
 themes: $(THEMES)

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,8 @@ LIBSSLFLAGS = $(shell pkg-config --cflags openssl)
 LIBSSLLIBS = $(shell pkg-config --libs openssl)
 LIBSECRETFLAGS =$(shell pkg-config --cflags libsecret-1)
 LIBSECRETLIBS =$(shell pkg-config --libs libsecret-1)
+LIBAPPINDICATORFLAGS = $(shell pkg-config --cflags appindicator3-0.1)
+LIBAPPINDICATORLIBS = $(shell pkg-config --libs appindicator3-0.1)
 
 CFLAGS += -std=gnu99 -O2 -Wall -Iinc -Wno-deprecated-declarations \
 		  $(DEFS) \
@@ -36,14 +38,16 @@ CFLAGS += -std=gnu99 -O2 -Wall -Iinc -Wno-deprecated-declarations \
 		  $(LIBCONFIGFLAGS) \
 		  $(LIBSOUPFLAGS) \
 		  $(LIBSSLFLAGS) \
-		  $(LIBSECRETFLAGS)
+		  $(LIBSECRETFLAGS) \
+		  $(LIBAPPINDICATORFLAGS)
 
 LDFLAGS += $(DBGFLAGS) \
 		   $(GTK3LIBS) \
 		   $(LIBCONFIGLIBS) \
 		   $(LIBSOUPLIBS) \
 		   $(LIBSSLLIBS) \
-		   $(LIBSECRETLIBS)
+		   $(LIBSECRETLIBS) \
+		   $(LIBAPPINDICATORLIBS)
 
 ifeq ($(OS),Windows_NT)
 LDFLAGS += -mwindows


### PR DESCRIPTION
This would use [`libappindicator`](https://launchpad.net/libappindicator) to implment system tray.

Tested on:
- [ ] GNOME (With appindicator extension)
- [x] KDE

Functionality:
- [ ] ~~Click to hide/show Srain windows~~ Looks like AppIndicator doesn't support this (No `active` event or mouse event)
- [x] Menu:
  - [x] Preferences
  - [x] About
  - [x] Exit
- [x] Icon (Normal / Highlight)

**Note**: Maybe AppIndicator doesn't support reading icons from gresources, so I have to change `data/Makefile` to install the attention icon too.