### PR TITLE
Fix implicit-declaration error on some systems

### DIFF
--- a/src/lib/path.c
+++ b/src/lib/path.c
@@ -37,6 +37,8 @@
 #include "i18n.h"
 #include "path.h"
 
+#include <stdlib.h>
+
 #ifdef _WIN32
 #include <windows.h>
 #include <Shlwapi.h>


### PR DESCRIPTION
I'm seeing this on openSUSE Leap 15.1
```
lib/path.c: In function 'srn_get_executable_path':
lib/path.c:370:4: warning: implicit declaration of function 'realpath'; did you mean 'renameat'? [-Wimplicit-function-declaration]
    realpath(PROC_SELF_EXE, rawPathName);
    ^~~~~~~~
    renameat
```
