### PR TITLE
Add /quote command

### DIFF
--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -1892,6 +1892,8 @@ static void irc_event_numeric(SircSession *sirc, int event,
                             srv->name, event, origin, count, buf->str);
 
                     g_string_free(buf, TRUE);
+
+                    srn_chat_add_recv_message(srv->chat, chat_user, params[count-1]);
                 }
             }
     }

--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -1881,7 +1881,7 @@ static void irc_event_numeric(SircSession *sirc, int event,
 
                     buf = g_string_new(NULL);
                     for (int i = 0; i < count; i++){
-                        buf = g_string_append(buf, params[count-1]); // reason
+                        buf = g_string_append(buf, params[i]); // reason
                         if (i != count - 1){
                             buf = g_string_append(buf, ", ");
                         }

--- a/src/core/chat_command.c
+++ b/src/core/chat_command.c
@@ -888,6 +888,19 @@ SrnRet on_command_unrender(SrnCommand *cmd, void *user_data){
             srv_user->nick, chat->name, pattern);
 }
 
+SrnRet on_command_quote(SrnCommand *cmd, void *user_data){
+    SrnServer *srv;
+    const char *msg;
+
+    srv = ctx_get_server(user_data);
+    g_return_val_if_fail(srv, SRN_ERR);
+
+    msg = srn_command_get_arg(cmd, 0);
+    g_return_val_if_fail(msg, SRN_ERR);
+
+    return sirc_cmd_raw(srv->irc, "%s\r\n", msg);
+}
+
 /*******************************************************************************
  * Misc
  ******************************************************************************/

--- a/src/core/chat_command.h
+++ b/src/core/chat_command.h
@@ -47,6 +47,7 @@ SrnRet on_command_away(SrnCommand *cmd, void *user_data);
 SrnRet on_command_pattern(SrnCommand *cmd, void *user_data);
 SrnRet on_command_render(SrnCommand *cmd, void *user_data);
 SrnRet on_command_unrender(SrnCommand *cmd, void *user_data);
+SrnRet on_command_quote(SrnCommand *cmd, void *user_data);
 
 static SrnCommandBinding cmd_bindings[] = {
     {
@@ -243,6 +244,12 @@ static SrnCommandBinding cmd_bindings[] = {
             SRN_COMMAND_EMPTY_OPT,
         },
         .cb = on_command_unrender,
+    },
+    {
+        .name = "/quote",
+        .argc = 1, // <command string>
+        .opt = { SRN_COMMAND_EMPTY_OPT },
+        .cb = on_command_quote,
     },
     SRN_COMMAND_EMPTY,
 };


### PR DESCRIPTION
This adds a /quote command for sending cusom IRC commands

Additionally processing of unknown numeric responses is cleaned up to properly show the response in the debug console, and extended to echo the response message in the server chat making the responses useful to the user even if not fully supported by srain.