### PR TITLE
Fix man-page build broken by sphinx 4.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -158,6 +158,8 @@ man_pages = [
      [author], 1)
 ]
 
+# Default in v4, set for v3
+man_make_section_directory = True
 
 # -- Options for Texinfo output -------------------------------------------
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -13,7 +13,7 @@ endforeach
 
 # `in` operator requires meson 0.49.0
 if doc_builders.contains('man')
-  install_man(join_paths(sphinx_build_dir, 'man', 'srain.1'))
+  install_man(join_paths(sphinx_build_dir, 'man', '1', 'srain.1'))
 endif
 
 # `in` operator requires meson 0.49.0


### PR DESCRIPTION
Current build with `sphinx v4.0.0-1` errors out with:
```
doc/meson.build:16:2: ERROR: File .../srain/builddir/doc/man/srain.1 does not exist.
```