### PR TITLE
Implement ISUPPORT parsing + the UTF8ONLY IRCv3 specification

### DIFF
--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -1349,6 +1349,31 @@ static void irc_event_numeric(SircSession *sirc, int event,
     g_return_if_fail(chat_user);
 
     switch (event) {
+        case SIRC_RFC_RPL_ISUPPORT:
+            {
+                for (int i = 1; i < count; i++){
+                    char *delim = strchr(params[i], '=');
+                    char *key, *value;
+                    if (delim){
+                        /* ISUPPORT token with value */
+                        key = g_strndup(params[i], delim - params[i]);
+                        value = g_strdup(delim+1);
+                    }
+                    else{
+                        /* ISUPPORT token with no value */
+                        key = g_strdup(params[i]);
+                        value = g_strdup("\0");
+                    }
+                    if (!strcmp(key, "UTF8ONLY")){
+                        /* https://ircv3.net/specs/extensions/utf8-only */
+                        str_assign(&srv->cfg->irc->encoding, "utf-8");
+                    }
+
+                    g_free(key);
+                    g_free(value);
+                }
+                /* Fall through, so ISUPPORT tokens are displayed */
+            }
         case SIRC_RFC_RPL_WELCOME:
         case SIRC_RFC_RPL_YOURHOST:
         case SIRC_RFC_RPL_CREATED:
@@ -1356,7 +1381,6 @@ static void irc_event_numeric(SircSession *sirc, int event,
         case SIRC_RFC_RPL_MOTD:
         case SIRC_RFC_RPL_ENDOFMOTD:
         case SIRC_RFC_RPL_MYINFO:
-        case SIRC_RFC_RPL_BOUNCE:
         case SIRC_RFC_RPL_LUSEROP:
         case SIRC_RFC_RPL_LUSERUNKNOWN:
         case SIRC_RFC_RPL_LUSERCHANNELS:


### PR DESCRIPTION
ISUPPORT syntax: https://modern.ircdocs.horse/#rplisupport-005

Relevant bits from the [UTF8ONLY specification](https://ircv3.net/specs/extensions/utf8-only):

> Servers publishing this token MUST NOT relay content [...] containing non-UTF-8 data to clients

> If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention.

This has the following effects:

* With the default configuration, this does nothing because Srain uses UTF-8 by default
* If a non-UTF-8 encoding is specified, it overrides the user's configuration if the server advertises UTF8ONLY.

This seems to affect only the incoming encoding, because Srain always send UTF-8 regardless of how I configured it. (Which is nice IMO, but it looks like a bug.)