### PR TITLE
Silence assertion failure on '/part'

### DIFF
--- a/src/lib/command.c
+++ b/src/lib/command.c
@@ -444,6 +444,9 @@ static SrnRet srn_command_parse(SrnCommand *cmd, void *user_data){
 
     /* Get arguments */
     for (int i = 0; i < binding->argc; i++){
+        if (!ptr){
+            goto missing_arg;
+        }
         if (i != binding->argc - 1){
             if (get_quote_arg(ptr, &cmd->argv[narg], &ptr) != SRN_OK){
                 goto missing_arg;
@@ -454,9 +457,9 @@ static SrnRet srn_command_parse(SrnCommand *cmd, void *user_data){
             }
         }
         narg++;
-        if (!ptr){
-            goto missing_arg;
-        }
+    }
+    if (!ptr){
+        goto missing_arg;
     }
 
     /* Debug output */

--- a/src/lib/command.c
+++ b/src/lib/command.c
@@ -458,9 +458,6 @@ static SrnRet srn_command_parse(SrnCommand *cmd, void *user_data){
         }
         narg++;
     }
-    if (!ptr){
-        goto missing_arg;
-    }
 
     /* Debug output */
     {


### PR DESCRIPTION
I get this error in the console when using '/part' with no argument:

```
** (srain:1402455): CRITICAL **: 15:14:11.703: get_quote_arg: assertion 'ptr && arg && next' failed
```

because `ptr` is NULL.

This extra check avoids it.