### PR TITLE
Silence "Unknown capability" warning on trailing ' '

### DIFF
--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -1085,7 +1085,7 @@ static void irc_event_cap(SircSession *sirc, const char *event,
     bool multiline;
     bool cap_end;
     const char *cap_event;
-    const char *rawcaps;
+    char *rawcaps;
     char **caps;
     SrnServer *srv;
 
@@ -1105,16 +1105,8 @@ static void irc_event_cap(SircSession *sirc, const char *event,
         g_return_if_fail(count == 4);
         rawcaps = params[3];
     }
+    rawcaps = g_strchomp(rawcaps);
     caps = g_strsplit(rawcaps, " ", 0);
-
-    /* The last item of caps is "" if rawcaps ends with a trailing ' ';
-     * which can happen from some servers.
-     * Strip it to avoid an "Unknown capability" warning. */
-    size_t nb_caps;
-    for (nb_caps = 0; caps[nb_caps]; nb_caps++);
-    if (nb_caps && !g_strcmp0(caps[nb_caps-1], "")) {
-        caps[nb_caps-1] = NULL;
-    }
 
     /* Process CAP event */
     if (g_ascii_strcasecmp(cap_event, "LS") == 0){

--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -1107,6 +1107,15 @@ static void irc_event_cap(SircSession *sirc, const char *event,
     }
     caps = g_strsplit(rawcaps, " ", 0);
 
+    /* The last item of caps is "" if rawcaps ends with a trailing ' ';
+     * which can happen from some servers.
+     * Strip it to avoid an "Unknown capability" warning. */
+    size_t nb_caps;
+    for (nb_caps = 0; caps[nb_caps]; nb_caps++);
+    if (nb_caps && !g_strcmp0(caps[nb_caps-1], "")) {
+        caps[nb_caps-1] = NULL;
+    }
+
     /* Process CAP event */
     if (g_ascii_strcasecmp(cap_event, "LS") == 0){
         GString *buf;


### PR DESCRIPTION
This happens on "CAP ACK" from Ergo and UnrealIRCd.