### PR TITLE
Make the buffer menu apply to the right-clicked item instead of the active buffer

### DIFF
--- a/src/sui/sui_side_bar_item.c
+++ b/src/sui/sui_side_bar_item.c
@@ -97,7 +97,7 @@ SuiSideBarItem *sui_side_bar_item_new(const char *title,
 void sui_side_bar_item_update(SuiSideBarItem *self,
         const char *nick, const char *msg){
     char *text;
-    GtkWidget *row;
+    GtkWidget *row, *event_box;
 
     text = strip_markup_tag(msg);
     g_return_if_fail(text);
@@ -115,8 +115,10 @@ void sui_side_bar_item_update(SuiSideBarItem *self,
 
     self->update_time = get_time_since_first_call_ms();
 
-    /* Mark as chagned */
-    row = gtk_widget_get_parent(GTK_WIDGET(self));
+    /* Mark as changed */
+    event_box = gtk_widget_get_parent(GTK_WIDGET(self));
+    g_return_if_fail(GTK_IS_EVENT_BOX(event_box));
+    row = gtk_widget_get_parent(GTK_WIDGET(event_box));
     g_return_if_fail(GTK_IS_LIST_BOX_ROW(row));
     gtk_list_box_row_changed(GTK_LIST_BOX_ROW(row));
 }


### PR DESCRIPTION
I find it confusing that click-clicking does not apply to the clicked element.

This commit inserts a GtkEventBox containing the SuiSideBarItem in GtkListBoxRow
instead of inserting SuiSideBarItem directly.

Here is the difference when right-clicking a channel buffer while a server buffer is active:

Before:
![screenshot-2022-01-23_11-34-41](https://user-images.githubusercontent.com/406946/150674660-de787b00-c510-437f-8547-a288aae0b214.png)

After:
![screenshot-2022-01-23_11-33-06](https://user-images.githubusercontent.com/406946/150674663-acf4df1f-9bb7-47da-96d5-d5983dacdb23.png)

Another difference is that clicking the empty space of the ListBox no longer shows a menu at all.