### PR TITLE
Add support for IRCv3 standard-replies

### DIFF
--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -92,6 +92,15 @@ static void irc_event_notice(SircSession *sirc, const char *event,
 static void irc_event_tagmsg(SircSession *sirc, const char *event,
         const char *origin, const char *params[], int count,
         const SircMessageContext *context);
+static void irc_event_fail(SircSession *sirc, const char *event,
+        const char *origin, const char *params[], int count,
+        const SircMessageContext *context);
+static void irc_event_warn(SircSession *sirc, const char *event,
+        const char *origin, const char *params[], int count,
+        const SircMessageContext *context);
+static void irc_event_note(SircSession *sirc, const char *event,
+        const char *origin, const char *params[], int count,
+        const SircMessageContext *context);
 static void irc_event_channel_notice(SircSession *sirc, const char *event,
         const char *origin, const char *params[], int count,
         const SircMessageContext *context);
@@ -144,6 +153,9 @@ void srn_application_init_irc_event(SrnApplication *app) {
     app->irc_events.privmsg = irc_event_privmsg;
     app->irc_events.notice = irc_event_notice;
     app->irc_events.tagmsg = irc_event_tagmsg;
+    app->irc_events.fail = irc_event_fail;
+    app->irc_events.warn = irc_event_warn;
+    app->irc_events.note = irc_event_note;
     app->irc_events.channel_notice = irc_event_channel_notice;
     app->irc_events.invite = irc_event_invite;
     app->irc_events.ctcp_req = irc_event_ctcp_req;
@@ -882,6 +894,46 @@ static void irc_event_tagmsg(SircSession *sirc, const char *event,
         const char *origin, const char **params, int count,
         const SircMessageContext *context){
     /* Not used yet */
+}
+
+static void irc_event_fail(SircSession *sirc, const char *event,
+        const char *origin, const char **params, int count,
+        const SircMessageContext *context){
+    /* https://ircv3.net/specs/extensions/standard-replies */
+    g_return_if_fail(count >= 3);
+    const char *command = params[0];
+    const char *code = params[1];
+    /* context = params[2]...params[count-2] */
+    const char *description = params[count-1];
+    SrnServer *srv = sirc_get_ctx(sirc);
+    srn_chat_add_error_message_fmt(srv->chat, context, _("FAIL[%1$s] %2$s: %3$s"), command, code, description);
+}
+
+static void irc_event_warn(SircSession *sirc, const char *event,
+        const char *origin, const char **params, int count,
+        const SircMessageContext *context){
+    /* https://ircv3.net/specs/extensions/standard-replies */
+    g_return_if_fail(count >= 3);
+    const char *command = params[0];
+    const char *code = params[1];
+    /* context = params[2]...params[count-2] */
+    const char *description = params[count-1];
+    SrnServer *srv = sirc_get_ctx(sirc);
+    srn_chat_add_error_message_fmt(srv->chat, context, _("WARN[%1$s] %2$s: %3$s"), command, code, description);
+}
+
+static void irc_event_note(SircSession *sirc, const char *event,
+        const char *origin, const char **params, int count,
+        const SircMessageContext *context){
+    /* https://ircv3.net/specs/extensions/standard-replies */
+    g_return_if_fail(count >= 3);
+    const char *command = params[0];
+    const char *code = params[1];
+    /* context = params[2]...params[count-2] */
+    const char *description = params[count-1];
+    SrnServer *srv = sirc_get_ctx(sirc);
+    SrnChat *chat = srn_server_get_chat(srv, origin);
+    srn_chat_add_misc_message_fmt(srv->chat, context, _("NOTE[%1$s] %2$s: %3$s"), command, code, description);
 }
 
 static void irc_event_channel_notice(SircSession *sirc, const char *event,

--- a/src/inc/sirc/sirc_event.h
+++ b/src/inc/sirc/sirc_event.h
@@ -60,6 +60,9 @@ typedef struct {
     SircEventCallback           ping;
     SircEventCallback           pong;
     SircEventCallback           error;
+    SircEventCallback           fail;
+    SircEventCallback           warn;
+    SircEventCallback           note;
     SircEventCallback           unknown;
 
     SircNumericEventCallback    numeric;

--- a/src/sirc/sirc_event_hdr.c
+++ b/src/sirc/sirc_event_hdr.c
@@ -224,6 +224,19 @@ void _sirc_event_hdr(SircSession *sirc, SircMessage *imsg, const SircMessageCont
              g_return_if_fail(events->error);
              events->tagmsg(sirc, event, origin, params, imsg->nparam, context);
         }
+         /* FAIL/WARN/NOTE are defined in https://ircv3.net/specs/extensions/standard-replies */
+         else if (strcasecmp(event, "FAIL") == 0){
+             g_return_if_fail(events->error);
+             events->fail(sirc, event, origin, params, imsg->nparam, context);
+        }
+         else if (strcasecmp(event, "WARN") == 0){
+             g_return_if_fail(events->error);
+             events->warn(sirc, event, origin, params, imsg->nparam, context);
+        }
+         else if (strcasecmp(event, "NOTE") == 0){
+             g_return_if_fail(events->error);
+             events->note(sirc, event, origin, params, imsg->nparam, context);
+        }
          else {
              g_return_if_fail(events->unknown);
              events->unknown(sirc, event, origin, params, imsg->nparam, context);


### PR DESCRIPTION
Srain doesn't currently use any of the specs that depend on standard-replies,
but Ergo sometimes emits them in addition to/instead of numerics (typically
when trying to express an error that doesn't have a numeric).

This is mostly just to suppress the error
`_sirc_event_hdr: assertion 'events->unknown' failed` when failing SASL
authentication on Ergo.

https://ircv3.net/specs/extensions/standard-replies

Example when failing SASL auth:
![screenshot-2022-01-23_13-12-01](https://user-images.githubusercontent.com/406946/150677796-3091cc7f-eca5-4ab5-97ad-611ddd1add09.png)
