### PR TITLE
Core(fix): sirc_message_context_get_time use-after-free

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -42,7 +42,7 @@ SrnMessage* srn_message_new(SrnChat *chat, SrnChatUser *user,
     self->sender = user;
     self->chat = chat;
     self->content = g_strdup(content);
-    self->time = sirc_message_context_get_time(context);
+    self->time = g_date_time_ref(sirc_message_context_get_time(context));
 
     // Inital render
     self->rendered_sender = g_markup_escape_text(user->srv_user->nick, -1);

--- a/src/inc/sirc/sirc_context.h
+++ b/src/inc/sirc/sirc_context.h
@@ -33,7 +33,7 @@ void sirc_message_context_free(SircMessageContext *context);
 
 /* Server-provided "time" tag if any, or the time the message was received/sent.
  * Never returns NULL. */
-const GDateTime* sirc_message_context_get_time(const SircMessageContext *context);
+GDateTime* sirc_message_context_get_time(const SircMessageContext *context);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(SircMessageContext, sirc_message_context_free)
 

--- a/src/sirc/sirc_context.c
+++ b/src/sirc/sirc_context.c
@@ -36,7 +36,7 @@ SircMessageContext* sirc_message_context_new(GDateTime* time) {
     return context;
 }
 
-const GDateTime* sirc_message_context_get_time(const SircMessageContext *context) {
+GDateTime* sirc_message_context_get_time(const SircMessageContext *context) {
     g_return_val_if_fail(context, NULL);
     return context->time;
 }


### PR DESCRIPTION
Close #355.
Replace #356.