### PR TITLE
Add support for invite-notify

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -58,7 +58,7 @@ batch               No
 chghost             No
 echo-message        No
 extended-join       No
-invite-notify       No
+invite-notify       Yes
 Monitor             No
 multi-prefix        No
 SASL v3.1           PLAIN,ECDSA-NIST256P-CHALLENGE

--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -945,8 +945,7 @@ static void irc_event_invite(SircSession *sirc, const char *event,
     if (sirc_target_equal(srv->user->nick, nick)){
         srn_chat_add_misc_message_with_user_fmt(chat, chat_user, context,
                 _("%1$s invites you into %2$s"), origin, chan);
-    }
-    else {
+    } else {
         srn_chat_add_misc_message_with_user_fmt(chat, chat_user, context,
                 _("%1$s invites %3$s into %2$s"), origin, chan, nick);
     }

--- a/src/core/app_irc_event.c
+++ b/src/core/app_irc_event.c
@@ -929,18 +929,28 @@ static void irc_event_invite(SircSession *sirc, const char *event,
     g_return_if_fail(srn_server_is_valid(srv));
     srv_user = srn_server_add_and_get_user(srv, origin);
     g_return_if_fail(srv_user);
-    chat = srn_server_add_and_get_chat(srv, origin);
-    g_return_if_fail(chat);
+
+    // Send to room chat if already open
+    chat = srn_server_get_chat(srv, chan);
+
+    // Otherwise, fall back to creating a chat with the sender
+    if (!chat) {
+        chat = srn_server_add_and_get_chat(srv, origin);
+        g_return_if_fail(chat);
+    }
+
     chat_user = srn_chat_add_and_get_user(chat, srv_user);
     g_return_if_fail(chat_user);
 
-    if (!sirc_target_equal(srv->user->nick, nick)){
-        WARN_FR("Received a invite message to %s", nick);
-        g_return_if_reached();
+    if (sirc_target_equal(srv->user->nick, nick)){
+        srn_chat_add_misc_message_with_user_fmt(chat, chat_user, context,
+                _("%1$s invites you into %2$s"), origin, chan);
+    }
+    else {
+        srn_chat_add_misc_message_with_user_fmt(chat, chat_user, context,
+                _("%1$s invites %3$s into %2$s"), origin, chan, nick);
     }
 
-    srn_chat_add_misc_message_with_user_fmt(chat, chat_user, context,
-            _("%1$s invites you into %2$s"), origin, chan);
 }
 
 static void irc_event_ctcp_req(SircSession *sirc, const char *event,

--- a/src/core/server_cap.c
+++ b/src/core/server_cap.c
@@ -55,7 +55,7 @@ static ServerCapSupport supported_caps[] = {
     //     .offset = offsetof(EnabledCap, identify_msg),
     // },
 
-    // /* IRCv3.1 */
+    // /* IRCv3 */
     // {
     //     .name = "multi-prefix",
     //     .offset = offsetof(EnabledCap, mulit_prefix),
@@ -78,8 +78,6 @@ static ServerCapSupport supported_caps[] = {
         .is_support = sasl_is_support,
         .on_enable = sasl_on_enable,
     },
-
-    // /* IRCv3.2 */
     {
         .name = "message-tags",
         .offset = offsetof(EnabledCap, message_tags),
@@ -101,6 +99,10 @@ static ServerCapSupport supported_caps[] = {
     //     .name = "chghost",
     //     .offset = offsetof(EnabledCap, chghost),
     // },
+    {
+        .name = "invite-notify",
+        .offset = offsetof(EnabledCap, invite_notify),
+    },
 
     // /* ZNC */
     // {

--- a/src/inc/core/server.h
+++ b/src/inc/core/server.h
@@ -171,20 +171,19 @@ struct _SrnServerConfig {
 };
 
 struct _EnabledCap {
-    // Version 3.1
+    // IRCv3
     bool identify_msg;
     bool mulit_prefix;
     bool away_notify;
     bool account_notify;
     bool extended_join;
     bool sasl;
-
-    // Version 3.2
     bool message_tags;
     bool server_time;
     bool userhost_in_names;
     bool cap_notify;
     bool chghost;
+    bool invite_notify;
 
     // Vendor-Specific
     bool znc_server_time_iso;


### PR DESCRIPTION
https://ircv3.net/specs/extensions/invite-notify

Also remove the comments about IRCv3.1 / IRCv3.2, because IRCv3 does not
classify its specs this way anymore.

How to test:

1. connect to a network that supports invite-notify (eg. irc.ergo.chat)
2. join a room, get opped
3. ask another op to invite someone
4. "X invites Y into Z" appears on the chat

Behavior is unchanged when being invited (ie. it still creates a private chat with the inviter)