### PR TITLE
Data(cleanup): remove GIMPNet

### DIFF
--- a/data/builtin.cfg
+++ b/data/builtin.cfg
@@ -133,12 +133,6 @@ server-list =
                                     # ``user`` configuration)
     },
     {
-        name = "GIMPNet"
-        addresses = ["irc.gimp.org:6697", "irc.gnome.org:6697"]
-        tls = true
-        encoding = "utf-8"
-    },
-    {
         name = "OFTC"
         addresses = ["irc.oftc.net:6697"]
         tls = true


### PR DESCRIPTION
https://discourse.gnome.org/t/gnome-moves-away-from-gimpnet-on-nov-25-15-00-utc/12046/17

Close #407.