### PR TITLE
Sui(impl): Add chat list order configuration

### DIFF
--- a/data/builtin.cfg
+++ b/data/builtin.cfg
@@ -12,6 +12,7 @@ auto-connect = []           # String array; Servers that are auto connected
                             # after startup
 server-visibility = true    # Bool; Whether the server buffer is visible
 scroll-on-new-message = false # Auto scroll when a new message is recieved
+chat-list-order = "recent"  # String; Set to "alphabet" for alphabetical order sort
 
 # If you want to report/fix a bug, terminal log will be helpful.
 log =

--- a/src/config/reader.c
+++ b/src/config/reader.c
@@ -296,6 +296,8 @@ static SrnRet read_application_config_from_cfg(config_t *cfg,
             &app_cfg->ui->window.server_visibility);
     config_lookup_bool_ex(cfg, "scroll-on-new-message",
             &app_cfg->ui->window.scroll_on_new_message);
+    config_lookup_string_ex(cfg, "chat-list-order",
+            &app_cfg->ui->window.chat_list_order);
 
     /* Read auto connect server list */
     config_setting_t *auto_connect;

--- a/src/core/app_config.c
+++ b/src/core/app_config.c
@@ -1,4 +1,5 @@
 #include "core/core.h"
+#include "i18n.h"
 
 SrnApplicationConfig *srn_application_config_new(void){
     SrnApplicationConfig *cfg;
@@ -16,5 +17,9 @@ void srn_application_config_free(SrnApplicationConfig *cfg){
 }
 
 SrnRet srn_application_config_check(SrnApplicationConfig *cfg){
+    if (g_strcmp0(cfg->ui->window.chat_list_order, CHAT_LIST_ORDER_RECENT) != 0
+            && g_strcmp0(cfg->ui->window.chat_list_order, CHAT_LIST_ORDER_ALPHABET) != 0){
+        return RET_ERR(_("Invalid chat-list-order configuration"));
+    }
     return SRN_OK;
 }

--- a/src/inc/sui/sui_config.h
+++ b/src/inc/sui/sui_config.h
@@ -37,7 +37,11 @@ struct _SuiWindowConfig {
     bool exit_on_close;
     bool server_visibility;
     bool scroll_on_new_message;
+    char *chat_list_order;
 };
+
+#define CHAT_LIST_ORDER_RECENT   "recent"
+#define CHAT_LIST_ORDER_ALPHABET "alphabet"
 
 struct _SuiApplicationConfig {
     char *theme;

--- a/src/sui/sui_config.c
+++ b/src/sui/sui_config.c
@@ -68,6 +68,7 @@ SrnRet sui_window_config_check(SuiWindowConfig *cfg){
 void sui_window_config_free(SuiWindowConfig *cfg){
     g_return_if_fail(cfg);
 
+    g_free(cfg->chat_list_order);
     g_free(cfg);
 }
 

--- a/src/sui/sui_side_bar.c
+++ b/src/sui/sui_side_bar.c
@@ -96,6 +96,7 @@ static gint list_sort_func(GtkListBoxRow *row1, GtkListBoxRow *row2,
     SuiSideBarItem *item1;
     SuiSideBarItem *item2;
     GtkWidget *event_box;
+    SuiWindowConfig* cfg;
 
     event_box = gtk_bin_get_child(GTK_BIN(row1));
     g_return_val_if_fail(GTK_IS_EVENT_BOX(event_box), 0);
@@ -104,6 +105,14 @@ static gint list_sort_func(GtkListBoxRow *row1, GtkListBoxRow *row2,
     event_box = gtk_bin_get_child(GTK_BIN(row2));
     g_return_val_if_fail(GTK_IS_EVENT_BOX(event_box), 0);
     item2 = SUI_SIDE_BAR_ITEM(gtk_bin_get_child(GTK_BIN(event_box)));
+
+    cfg = sui_window_get_config(sui_common_get_cur_window());
+    if (g_strcmp0(cfg->chat_list_order, CHAT_LIST_ORDER_ALPHABET) == 0){
+        return g_strcmp0(
+                sui_side_bar_item_get_title(item1),
+                sui_side_bar_item_get_title(item2)
+                );
+    }
 
     time1 = sui_side_bar_item_get_update_time(item1);
     time2 = sui_side_bar_item_get_update_time(item2);

--- a/src/sui/sui_side_bar_item.c
+++ b/src/sui/sui_side_bar_item.c
@@ -158,6 +158,10 @@ unsigned long sui_side_bar_item_get_update_time(SuiSideBarItem *self){
     return self->update_time;
 }
 
+const gchar *sui_side_bar_item_get_title(SuiSideBarItem *self){
+    return gtk_label_get_text(self->title_label);
+}
+
 /*****************************************************************************
  * Static functions
  *****************************************************************************/

--- a/src/sui/sui_side_bar_item.h
+++ b/src/sui/sui_side_bar_item.h
@@ -37,6 +37,7 @@ void sui_side_bar_item_inc_count(SuiSideBarItem *self);
 void sui_side_bar_item_clear_count(SuiSideBarItem *self);
 
 unsigned long sui_side_bar_item_get_update_time(SuiSideBarItem *self);
+const gchar *sui_side_bar_item_get_title(SuiSideBarItem *self);
 
 #endif /* __SUI_SIDE_BAR_ITEM_H */
 


### PR DESCRIPTION
Adds a way to sort channels alphabetically in the sidebar

Notes for the review:
* I am not quite sure about the naming
* There are no checks done on the new `sidebar-sort` configuration value, but no other settings appear to have such checks. The *default* value I have provided in `builtin.cfg` is de facto arbitrary.
* I wonder if there is a better way to access the configuration from `list_sort_func`
* It's possible that I have missed some error checks to be done