### PR TITLE
Core(fix): remove bool typedef in C23

### DIFF
--- a/src/core/app.c
+++ b/src/core/app.c
@@ -234,7 +234,7 @@ SrnRet srn_application_add_server(SrnApplication *app, const char *name){
     SrnRet ret;
     SrnServerConfig *srv_cfg;
 
-    srv_cfg = srn_server_config_new(name);
+    srv_cfg = srn_server_config_new();
     ret = srn_config_manager_read_server_config(app->cfg_mgr, srv_cfg, name);
     if (!RET_IS_OK(ret)){
         goto ERR;

--- a/src/filter/filter2.h
+++ b/src/filter/filter2.h
@@ -32,7 +32,7 @@ typedef struct _SrnMessageFilter SrnMessageFilter;
 struct _SrnMessageFilter {
     const char *name;
     void (*init) (void);
-    SrnRet (*filter) (const SrnMessage *msg);
+    bool (*filter) (const SrnMessage *msg);
     void (*finalize) (void);
 };
 

--- a/src/inc/srain.h
+++ b/src/inc/srain.h
@@ -22,7 +22,9 @@
 #include <stdint.h>
 #include <glib.h>
 
+#if defined __STDC_VERSION__ && __STDC_VERSION__ <= 201710L
 typedef gboolean bool;
+#endif
 
 /* General result value */
 #define SRN_OK      0


### PR DESCRIPTION
In C23 (the default for GCC 15), bool is a keyword, so typedef needs to be removed.
```
../srain-1.8.0/src/inc/srain.h:26:18: error: two or more data types in declaration specifiers
   26 | typedef gboolean bool;
      |                  ^~~~
```
```
../srain-1.8.0/src/filter/user_filter.c:32:15: error: initialization of ‘SrnRet (*)(const SrnMessage *)’ {aka ‘int (*)(const struct _SrnMessage *)’} from incompatible pointe
r type ‘_Bool (*)(const SrnMessage *)’ {aka ‘_Bool (*)(const struct _SrnMessage *)’} [-Wincompatible-pointer-types]
   32 |     .filter = filter,
      |               ^~~~~~
```
Also fixes an oversight in 7f27c41.
```
../srain-1.8.0/src/core/app.c: In function ‘srn_application_add_server’:
../srain-1.8.0/src/core/app.c:237:15: error: too many arguments to function ‘srn_server_config_new’
  237 |     srv_cfg = srn_server_config_new(name);
      |               ^~~~~~~~~~~~~~~~~~~~~
```
Downstream Bug: https://bugs.gentoo.org/945702